### PR TITLE
fix: search Contributor input width fix and  autofill color issue

### DIFF
--- a/css/contributors.css
+++ b/css/contributors.css
@@ -117,10 +117,24 @@ body{
     background:var(--darkbg);
     outline:0;
     color:#eee;
-    width:300px;
+    width:20rem;
     accent-color:var(--lightt);
     box-shadow:none
 }
+@media (max-width:768px){
+    .form-control,.form-control:focus,.from-control:active{
+        width:14rem;
+    }
+}
+/* To Make Input field transparent during auto-complete */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active {
+  transition: background-color 5000s;
+  -webkit-text-fill-color: #fff !important;
+}
+
 .light .form-control{
     background-color:#fff;
     border-color:#eee;


### PR DESCRIPTION


# Problem
- Contributors Input length is overflowing in Mobile 
- The Input box focus/active color changes during autofill
# Solution
- Need to handle width via media queries 
- For handling autofill we can use text-fill property

## Changes proposed in this Pull Request :
-  `1.` added media query to handle the width of input box
-  `2.` added text-fill-color with transition bg-color to make it transparent


## Other changes
- none
