### PR TITLE
Fix search bar text in light color

### DIFF
--- a/css/contributors.css
+++ b/css/contributors.css
@@ -153,6 +153,7 @@ input:-webkit-autofill:active {
 .light .form-control {
   background-color: #fff;
   border-color: #eee;
+  color: #000;
   outline: 0;
   box-shadow: none;
 }


### PR DESCRIPTION
# Problem
#2207

# Solution
Set the Input bar set to black for light-mode

## Changes proposed in this Pull Request :
- Set the search Input bar set to black for light-mode

<img width="355" alt="image" src="https://user-images.githubusercontent.com/58323485/193737745-792ce024-df69-4235-a649-a9a52bd41da7.png">

