### PR TITLE
Calculating area of shapes using Interfaces in go.

### DIFF
--- a/Program's_Contributed_By_Contributors/Golang Programs/areaFigure.go
+++ b/Program's_Contributed_By_Contributors/Golang Programs/areaFigure.go
@@ -1,0 +1,37 @@
+package main
+import (
+	"fmt"
+	"math"
+)
+type circle struct {
+	radius float64
+}
+type square struct {
+	side float64
+}
+type rectangle struct {
+	length, width float64
+}
+func (c circle) area() float64 {
+	return math.Pi * c.radius * c.radius
+}
+func (s square) area() float64 {
+	return s.side * s.side
+}
+func (r rectangle) area() float64 {
+	return r.length * r.width
+}
+type shape interface {
+	area() float64
+}
+func info(s shape) {
+	fmt.Println("Area:", s.area())
+}
+func main() {
+	c := circle{radius: 5}
+	s := square{side: 5}
+	r := rectangle{length: 5, width: 10}
+	info(c)
+	info(s)
+	info(r)
+}


### PR DESCRIPTION

# Problem
- Calculating area of shapes such as circle, square, rectangle, etc in golang.
# Solution
- To solve this particular problem in "golang fashion" I implemented an interface which calculates the area of all such figures implementing the similar "area" method.

## Changes proposed in this Pull Request :
-  `1.`<!-- transform property added to box-item on hover -->
-  `..`

## Other changes
-
