### PR TITLE
Remove extra margin on stats message page

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
     </div>
     <div class="footer mt-auto py-3 bg-light text-center">
         <div class="container">
-            <span class="text-muted"><div id="stats" style="margin-top: 1rem;"></div></span>
+            <span class="text-muted"><div id="stats"></div></span>
         </div>
     </div>
     <footer>


### PR DESCRIPTION
# Problem
- There is an extra margin on top of the stats message below the page

# Solution
- Removing it to have a symmetrical margins in y axis

## Changes proposed in this Pull Request :
-  remove the style `margin-top: 1rem;`

## Other changes
-
