### PR TITLE
Replace outdated URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ For more information on syncing forks [read this article from Github](https://he
   - We are two programmers from India [Anmol](https://www.linkedin.com/in/fineanmol/)
   and [Ritesh](https://github.com/ritesh2905). We are doing this because we love Open Source and Hacktoberfest. We want to make it easier for people to get started with Hacktoberfest and Open Source.
 - Why are you not using digitalocean?
-  - Because we only know JavaScript and suck at servers. We use [now](https://zeit.co/now) instead.
+  - Because we only know JavaScript and suck at servers. We use [Vercel](https://vercel.com) instead.
 
 - Should I come closer to the text saying 'Don't come closer' on the left side of the home tab ?
   - Nope.


### PR DESCRIPTION

# Problem

Zeit's now has been renamed "Vercel" more than 2 years ago. Also, the domain has changed.

More info here: https://vercel.com/blog/zeit-is-now-vercel

# Solution

Replace [now](https://zeit.co/now) with [Vercel](https://vercel.com)