### PR TITLE
Added program for removing duplicates from a list in PROLOG

### DIFF
--- a/remove_duplicate_list_prolog.pl
+++ b/remove_duplicate_list_prolog.pl
@@ -1,0 +1,10 @@
+member([H|T],N):- H=:=N.
+member([H|T],N):- H=\=N, member(T,N).
+
+remove_duplicate([],[]).
+remove_duplicate([Head|Tail],Result):-
+member(Tail,Head),!,
+remove_duplicate(Tail, Result).
+
+remove_duplicate([Head|Tail],[Head|Result]):-
+remove_duplicate(Tail, Result).


### PR DESCRIPTION

# Problem
Remove duplicates from a list in Prolog
# Solution
member([H|T],N):- H=:=N.
member([H|T],N):- H=\=N, member(T,N).

remove_duplicate([],[]).
remove_duplicate([Head|Tail],Result):-
member(Tail,Head),!,
remove_duplicate(Tail, Result).

remove_duplicate([Head|Tail],[Head|Result]):-
remove_duplicate(Tail, Result).

## Changes proposed in this Pull Request :
-  `1.` Added a program
